### PR TITLE
Fix compilation

### DIFF
--- a/source/vibe/data/sdl.d
+++ b/source/vibe/data/sdl.d
@@ -3,6 +3,7 @@
 module vibe.data.sdl;
 
 import vibe.data.serialization;
+import vibe.data.json;
 import sdlang;
 import std.datetime : Date, DateTime, SysTime, TimeOfDay, UTC;
 import std.meta : allSatisfy, staticIndexOf;


### PR DESCRIPTION
Compilation fails currently due to a missing import for vibe.data.json, this PR adds a reference to vibe.data.json.